### PR TITLE
Add GitHub Pages deployment automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build site
+        run: npm run build
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ View your app in AI Studio: https://ai.studio/apps/drive/15mormDQ9ERK0BnLer052AP
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Deploy to GitHub Pages
+
+The repository includes a GitHub Actions workflow that publishes the production build to GitHub Pages whenever commits land on the `main` branch.
+
+1. Enable GitHub Pages for the repository and select **GitHub Actions** as the source.
+2. Ensure the `main` branch contains the workflow defined in [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+3. Push to `main` (or trigger the workflow manually). The workflow sets the correct base path for the Vite build and deploys the contents of the `dist` folder to GitHub Pages.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,18 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const basePath = (() => {
+      const raw = env.VITE_BASE_PATH ?? env.BASE_PATH;
+      if (!raw) {
+        return '/';
+      }
+
+      const withLeadingSlash = raw.startsWith('/') ? raw : `/${raw}`;
+      return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+    })();
+
     return {
+      base: basePath,
       server: {
         port: 3000,
         host: '0.0.0.0',


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish the app to GitHub Pages from the main branch
- normalize the Vite base path configuration for GitHub Pages builds and document the deployment process

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d86782b39c8324a1a5de7198138837