### PR TITLE
Add rename and delete controls to document header

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { ListItemNode, AppFile, UserProfile } from './types';
 import Editor from './components/Editor';
 import { parseMarkdown, serializeToMarkdown } from './services/markdownParser';
-import { FolderPlusIcon, SaveIcon, PlusIcon, XCircleIcon } from './components/icons';
+import { FolderPlusIcon, SaveIcon, PlusIcon, XCircleIcon, TrashIcon } from './components/icons';
 import { firebaseConfig } from './services/firebaseConfig';
 import * as firebaseService from './services/firebase';
 import * as localService from './services/localStorage';
@@ -50,6 +50,8 @@ export default function App() {
   const [isNewFileDialogOpen, setIsNewFileDialogOpen] = useState(false);
   const [itemToFocusId, setItemToFocusId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<{ type: 'error' | 'info'; text: string } | null>(null);
+  const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+  const [fileToRename, setFileToRename] = useState<AppFile | null>(null);
 
   const isLoggedIn = useMemo(() => !!user, [user]);
 
@@ -223,6 +225,37 @@ export default function App() {
     }
   };
 
+  const handleRenameFile = async (newName: string) => {
+    const targetFile = fileToRename || currentFile;
+    if (!targetFile) {
+      return;
+    }
+
+    try {
+      if (user?.uid) {
+        await firebaseService.renameDocument(targetFile.id, newName);
+      } else {
+        await localService.renameDocument(targetFile.id, newName);
+      }
+
+      setFiles(prev => prev.map(file => file.id === targetFile.id ? { ...file, name: newName } : file));
+      if (currentFile?.id === targetFile.id) {
+        setCurrentFile({ ...currentFile, name: newName });
+      }
+      setStatusMessage(null);
+    } catch (error) {
+      console.error('Error renaming file:', error);
+      setStatusMessage({
+        type: 'error',
+        text: 'Unable to rename the document. Please try again.',
+      });
+    } finally {
+      setIsRenameDialogOpen(false);
+      setFileToRename(null);
+      await listFiles();
+    }
+  };
+
   const onUpdateText = (id: string, text: string) => {
     const newDoc = JSON.parse(JSON.stringify(docContent));
     findAndModifyNode(newDoc, id, (node) => {
@@ -375,7 +408,29 @@ export default function App() {
             <button onClick={() => setSidebarOpen(!sidebarOpen)} className="md:hidden mr-3 p-2 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" /></svg>
             </button>
-            <h2 className="text-lg font-semibold truncate">{currentFile?.name || 'No file selected'}</h2>
+            {currentFile ? (
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={() => {
+                    setFileToRename(currentFile);
+                    setIsRenameDialogOpen(true);
+                  }}
+                  className="text-lg font-semibold truncate hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+                  title="Rename document"
+                >
+                  {currentFile.name}
+                </button>
+                <button
+                  onClick={() => deleteFile(currentFile)}
+                  className="p-1.5 rounded-full text-red-500 hover:bg-red-100 dark:hover:bg-red-900/50 focus:outline-none focus:ring-2 focus:ring-red-400"
+                  title="Delete document"
+                >
+                  <TrashIcon className="w-5 h-5" />
+                </button>
+              </div>
+            ) : (
+              <h2 className="text-lg font-semibold truncate">No file selected</h2>
+            )}
           </div>
           {currentFile && (
             <button onClick={saveFile} disabled={isSaving} className="flex items-center space-x-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors disabled:bg-indigo-400 disabled:cursor-not-allowed">
@@ -438,6 +493,18 @@ export default function App() {
         confirmText="Create"
         initialValue="New Document.md"
         placeholder="Enter file name"
+      />
+      <TextInputDialog
+        isOpen={isRenameDialogOpen}
+        onClose={() => {
+          setIsRenameDialogOpen(false);
+          setFileToRename(null);
+        }}
+        onConfirm={handleRenameFile}
+        title="Rename Document"
+        confirmText="Rename"
+        initialValue={fileToRename?.name || currentFile?.name || ''}
+        placeholder="Enter new file name"
       />
     </div>
   );

--- a/services/firebase.ts
+++ b/services/firebase.ts
@@ -87,3 +87,11 @@ export const deleteDocument = (docId: string) => {
     const docRef = doc(db, 'documents', docId);
     return deleteDoc(docRef);
 };
+
+export const renameDocument = (docId: string, name: string) => {
+    const docRef = doc(db, 'documents', docId);
+    return updateDoc(docRef, {
+        name,
+        updatedAt: serverTimestamp(),
+    });
+};

--- a/services/localStorage.ts
+++ b/services/localStorage.ts
@@ -59,3 +59,11 @@ export const deleteDocument = async (docId: string): Promise<void> => {
   localStorage.removeItem(`${FILE_CONTENT_PREFIX}${docId}`);
   return Promise.resolve();
 };
+
+export const renameDocument = async (docId: string, name: string): Promise<void> => {
+  const index = getFileIndex().map(file =>
+    file.id === docId ? { ...file, name } : file
+  );
+  setFileIndex(index);
+  return Promise.resolve();
+};


### PR DESCRIPTION
## Summary
- add a rename dialog that is triggered from the document title in the editor header
- expose rename helpers in firebase and local storage services so document names stay in sync
- add a delete button next to the current document name for quick removal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91a605c30832491b01e44d13f8151