### PR TITLE
Add debounced auto-save for local documents

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -108,7 +108,7 @@ export default function App() {
   useEffect(() => {
     listFiles();
   }, [listFiles]);
-  
+
   const handleLogin = async () => {
     try {
       await firebaseService.signInWithGoogle();
@@ -199,6 +199,18 @@ export default function App() {
       setTimeout(() => setIsSaving(false), 1000);
     }
   }, [currentFile, docContent, user]);
+
+  useEffect(() => {
+    if (!currentFile || user?.uid) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      saveFile();
+    }, 1000);
+
+    return () => clearTimeout(timeoutId);
+  }, [currentFile, docContent, saveFile, user]);
 
   const deleteFile = async (file: AppFile) => {
     if (!window.confirm(`Are you sure you want to delete "${file.name}"? This action cannot be undone.`)) {


### PR DESCRIPTION
## Summary
- add an effect in the app to persist changes to localStorage when editing without authentication
- debounce automatic saves by one second to avoid redundant writes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91b29078c83248db9641d4370a2a4