### PR TITLE
Add markdown import/export dialogs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,8 +2,9 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { ListItemNode, AppFile, UserProfile } from './types';
 import Editor from './components/Editor';
+import MarkdownDialog from './components/MarkdownDialog';
 import { parseMarkdown, serializeToMarkdown } from './services/markdownParser';
-import { FolderPlusIcon, SaveIcon, PlusIcon, XCircleIcon } from './components/icons';
+import { FolderPlusIcon, SaveIcon, PlusIcon, XCircleIcon, ArrowDownTrayIcon, ArrowUpTrayIcon } from './components/icons';
 import { firebaseConfig } from './services/firebaseConfig';
 import * as firebaseService from './services/firebase';
 import * as localService from './services/localStorage';
@@ -50,6 +51,10 @@ export default function App() {
   const [isNewFileDialogOpen, setIsNewFileDialogOpen] = useState(false);
   const [itemToFocusId, setItemToFocusId] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<{ type: 'error' | 'info'; text: string } | null>(null);
+  const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
+  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
+  const [importMarkdownText, setImportMarkdownText] = useState('');
+  const [exportMarkdownText, setExportMarkdownText] = useState('');
 
   const isLoggedIn = useMemo(() => !!user, [user]);
 
@@ -108,6 +113,10 @@ export default function App() {
   useEffect(() => {
     listFiles();
   }, [listFiles]);
+
+  useEffect(() => {
+    setExportMarkdownText(serializeToMarkdown(docContent));
+  }, [docContent]);
   
   const handleLogin = async () => {
     try {
@@ -127,6 +136,59 @@ export default function App() {
   
   const openNewFileDialog = () => {
     setIsNewFileDialogOpen(true);
+  };
+
+  const openImportMarkdownDialog = () => {
+    setImportMarkdownText(serializeToMarkdown(docContent));
+    setIsImportDialogOpen(true);
+  };
+
+  const openExportMarkdownDialog = () => {
+    setExportMarkdownText(serializeToMarkdown(docContent));
+    setIsExportDialogOpen(true);
+  };
+
+  const handleImportMarkdown = (markdown: string) => {
+    const trimmed = markdown.trim();
+
+    if (!trimmed) {
+      setDocContent([]);
+      setStatusMessage({
+        type: 'info',
+        text: 'Document cleared from imported markdown. Remember to save your changes.',
+      });
+      setImportMarkdownText('');
+      setItemToFocusId(null);
+      return true;
+    }
+
+    const parsedNodes = parseMarkdown(markdown);
+
+    if (parsedNodes.length === 0) {
+      setStatusMessage({
+        type: 'error',
+        text: 'No headings (#) were found in the pasted markdown. Please ensure each heading starts with the # symbol.',
+      });
+      return false;
+    }
+
+    setDocContent(parsedNodes);
+    const serialized = serializeToMarkdown(parsedNodes);
+    setImportMarkdownText(serialized);
+    setExportMarkdownText(serialized);
+    setItemToFocusId(parsedNodes[0].id);
+    setStatusMessage({
+      type: 'info',
+      text: 'Markdown imported successfully. Remember to save your changes.',
+    });
+    return true;
+  };
+
+  const handleMarkdownCopySuccess = () => {
+    setStatusMessage({
+      type: 'info',
+      text: 'Markdown copied to clipboard.',
+    });
   };
 
   const handleCreateNewFile = async (fileName: string) => {
@@ -377,12 +439,31 @@ export default function App() {
             </button>
             <h2 className="text-lg font-semibold truncate">{currentFile?.name || 'No file selected'}</h2>
           </div>
-          {currentFile && (
-            <button onClick={saveFile} disabled={isSaving} className="flex items-center space-x-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors disabled:bg-indigo-400 disabled:cursor-not-allowed">
-              <SaveIcon className="w-5 h-5"/>
-              <span>{isSaving ? 'Saving...' : 'Save'}</span>
+          <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={openImportMarkdownDialog}
+              className="flex items-center space-x-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-700/40 px-3 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+            >
+              <ArrowDownTrayIcon className="h-5 w-5" />
+              <span className="hidden sm:inline">Import</span>
             </button>
-          )}
+            <button
+              type="button"
+              onClick={openExportMarkdownDialog}
+              disabled={docContent.length === 0}
+              className={`flex items-center space-x-2 rounded-lg border border-slate-200 dark:border-slate-700 px-3 py-2 text-sm font-medium transition-colors ${docContent.length === 0 ? 'cursor-not-allowed bg-slate-100 text-slate-400 dark:bg-slate-700/30 dark:text-slate-500' : 'bg-white text-slate-700 hover:bg-slate-100 dark:bg-slate-700/40 dark:text-slate-200 dark:hover:bg-slate-700'}`}
+            >
+              <ArrowUpTrayIcon className="h-5 w-5" />
+              <span className="hidden sm:inline">Export</span>
+            </button>
+            {currentFile && (
+              <button onClick={saveFile} disabled={isSaving} className="flex items-center space-x-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors disabled:bg-indigo-400 disabled:cursor-not-allowed">
+                <SaveIcon className="w-5 h-5"/>
+                <span>{isSaving ? 'Saving...' : 'Save'}</span>
+              </button>
+            )}
+          </div>
         </header>
 
         {statusMessage && (
@@ -429,6 +510,29 @@ export default function App() {
           )}
         </div>
       </main>
+
+      <MarkdownDialog
+        isOpen={isImportDialogOpen}
+        title="Import markdown"
+        description="Paste markdown headings to replace the current document outline. Existing content will be overwritten when you import."
+        confirmText="Import"
+        initialValue={importMarkdownText}
+        placeholder="# Heading"
+        onClose={() => setIsImportDialogOpen(false)}
+        onConfirm={handleImportMarkdown}
+      />
+
+      <MarkdownDialog
+        isOpen={isExportDialogOpen}
+        title="Export markdown"
+        description="Copy the markdown representation of the current document."
+        initialValue={exportMarkdownText}
+        readOnly
+        cancelText={null}
+        onClose={() => setIsExportDialogOpen(false)}
+        showCopyButton={docContent.length > 0}
+        onCopySuccess={handleMarkdownCopySuccess}
+      />
 
       <TextInputDialog
         isOpen={isNewFileDialogOpen}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ View your app in AI Studio: https://ai.studio/apps/drive/15mormDQ9ERK0BnLer052AP
 4. Run the app:
    `npm run dev`
 
+## Markdown import/export
+
+Use the **Import** button in the editor toolbar to paste markdown that will replace the current outline. The **Export** button
+opens a dialog where you can copy the generated markdown for the document.
+
 ## Deploy to GitHub Pages
 
 The repository includes a GitHub Actions workflow that publishes the production build to GitHub Pages whenever commits land on the `main` branch.

--- a/components/MarkdownDialog.tsx
+++ b/components/MarkdownDialog.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface MarkdownDialogProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string | null;
+  initialValue?: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  onClose: () => void;
+  onConfirm?: (value: string) => boolean | void;
+  showCopyButton?: boolean;
+  onCopySuccess?: () => void;
+}
+
+const MarkdownDialog: React.FC<MarkdownDialogProps> = ({
+  isOpen,
+  title,
+  description,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  initialValue = '',
+  placeholder = '',
+  readOnly = false,
+  onClose,
+  onConfirm,
+  showCopyButton = false,
+  onCopySuccess,
+}) => {
+  const [value, setValue] = useState(initialValue);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setValue(initialValue);
+      setCopyStatus(null);
+      setTimeout(() => {
+        if (!readOnly) {
+          textareaRef.current?.focus();
+        } else {
+          textareaRef.current?.select();
+        }
+      }, 50);
+    }
+  }, [initialValue, isOpen, readOnly]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleConfirm = () => {
+    if (!onConfirm) {
+      onClose();
+      return;
+    }
+
+    const result = onConfirm(value);
+    if (result !== false) {
+      onClose();
+    }
+  };
+
+  const handleCopy = async () => {
+    if (typeof navigator === 'undefined') {
+      setCopyStatus('Clipboard API is unavailable.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyStatus('Copied to clipboard.');
+      onCopySuccess?.();
+      setTimeout(() => setCopyStatus(null), 2000);
+    } catch (error) {
+      console.error('Failed to copy markdown', error);
+      setCopyStatus('Failed to copy. Try copying manually.');
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="markdown-dialog-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl rounded-lg bg-white dark:bg-slate-800 p-6 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4">
+          <h2 id="markdown-dialog-title" className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h2>
+          {description && (
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{description}</p>
+          )}
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          className="h-64 w-full resize-none rounded-md border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900/60 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          {showCopyButton && (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="rounded-md border border-slate-300 dark:border-slate-600 px-3 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+              >
+                Copy to clipboard
+              </button>
+              {copyStatus && (
+                <span className="text-xs text-slate-500 dark:text-slate-400">{copyStatus}</span>
+              )}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3">
+            {cancelText !== null && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md bg-slate-100 dark:bg-slate-700 px-4 py-2 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600"
+              >
+                {cancelText}
+              </button>
+            )}
+            {onConfirm ? (
+              <button
+                type="button"
+                onClick={handleConfirm}
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              >
+                {confirmText}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              >
+                Close
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownDialog;

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -43,3 +43,15 @@ export const XCircleIcon = (props: React.SVGProps<SVGSVGElement>) => (
         <path strokeLinecap="round" strokeLinejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
     </svg>
 );
+
+export const ArrowDownTrayIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M7.5 10.5 12 15m0 0 4.5-4.5M12 15V3" />
+  </svg>
+);
+
+export const ArrowUpTrayIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 8.25V6A2.25 2.25 0 0 1 5.25 3.75h13.5A2.25 2.25 0 0 1 21 6v2.25M7.5 13.5 12 9m0 0 4.5 4.5M12 9v11.25" />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- add a reusable markdown dialog component for import/export flows
- add toolbar buttons to import pasted markdown and export the current document
- document the new markdown workflow in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91aeea4248324930c7908e28fbbce