### PR TITLE
Add collapsible editor nodes with persisted local view state

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { ListItemNode, AppFile, UserProfile } from './types';
+import { ListItemNode, AppFile, UserProfile, DocumentViewState } from './types';
 import Editor from './components/Editor';
 import { parseMarkdown, serializeToMarkdown } from './services/markdownParser';
 import { FolderPlusIcon, SaveIcon, PlusIcon, XCircleIcon } from './components/icons';
@@ -31,11 +31,47 @@ const flattenNodesForNavigation = (nodes: ListItemNode[]): string[] => {
   let ids: string[] = [];
   for (const node of nodes) {
     ids.push(node.id);
-    if (node.children.length > 0) {
+    if (node.children.length > 0 && !node.isCollapsed) {
       ids = ids.concat(flattenNodesForNavigation(node.children));
     }
   }
   return ids;
+};
+
+const collectCollapsedPaths = (nodes: ListItemNode[], basePath: number[] = []): number[][] => {
+  const paths: number[][] = [];
+
+  nodes.forEach((node, index) => {
+    const currentPath = [...basePath, index];
+    if (node.isCollapsed) {
+      paths.push(currentPath);
+    }
+
+    if (node.children.length > 0) {
+      paths.push(...collectCollapsedPaths(node.children, currentPath));
+    }
+  });
+
+  return paths;
+};
+
+const applyCollapsedState = (nodes: ListItemNode[], collapsedPaths: number[][]): ListItemNode[] => {
+  const collapsedSet = new Set(collapsedPaths.map(path => path.join('.')));
+
+  const traverse = (items: ListItemNode[], parentPath: number[] = []): ListItemNode[] =>
+    items.map((item, index) => {
+      const currentPath = [...parentPath, index];
+      const pathKey = currentPath.join('.');
+      const isCollapsed = collapsedSet.has(pathKey);
+
+      return {
+        ...item,
+        isCollapsed,
+        children: traverse(item.children, currentPath),
+      };
+    });
+
+  return traverse(nodes);
 };
 
 export default function App() {
@@ -52,6 +88,19 @@ export default function App() {
   const [statusMessage, setStatusMessage] = useState<{ type: 'error' | 'info'; text: string } | null>(null);
 
   const isLoggedIn = useMemo(() => !!user, [user]);
+
+  const cloneDocContent = useCallback(() => {
+    return JSON.parse(JSON.stringify(docContent)) as ListItemNode[];
+  }, [docContent]);
+
+  const persistLocalViewState = useCallback((nodes: ListItemNode[]) => {
+    if (!user?.uid && currentFile) {
+      const viewState: DocumentViewState = {
+        collapsedPaths: collectCollapsedPaths(nodes),
+      };
+      void localService.updateDocumentViewState(currentFile.id, viewState);
+    }
+  }, [currentFile, user]);
 
   const listFiles = useCallback(async (targetUser: UserProfile | null = user) => {
     setIsLoading(true);
@@ -160,14 +209,20 @@ export default function App() {
     setIsLoading(true);
     try {
       let content: string | null;
+      let viewState: DocumentViewState | null = null;
       if (user?.uid) {
         content = await firebaseService.getDocumentContent(file.id);
       } else {
         content = await localService.getDocumentContent(file.id);
+        viewState = await localService.getDocumentViewState(file.id);
       }
-      
+
       if (content !== null) {
-        setDocContent(parseMarkdown(content));
+        const parsedNodes = parseMarkdown(content);
+        const nodesWithState = viewState
+          ? applyCollapsedState(parsedNodes, viewState.collapsedPaths)
+          : parsedNodes;
+        setDocContent(nodesWithState);
         setCurrentFile(file);
       } else {
         console.error("File not found or content is empty, creating from template.");
@@ -192,6 +247,9 @@ export default function App() {
         await firebaseService.updateDocument(currentFile.id, markdownContent);
       } else {
         await localService.updateDocument(currentFile.id, markdownContent);
+        await localService.updateDocumentViewState(currentFile.id, {
+          collapsedPaths: collectCollapsedPaths(docContent),
+        });
       }
     } catch (e) {
       console.error("Error saving file", e);
@@ -224,16 +282,16 @@ export default function App() {
   };
 
   const onUpdateText = (id: string, text: string) => {
-    const newDoc = JSON.parse(JSON.stringify(docContent));
+    const newDoc = cloneDocContent();
     findAndModifyNode(newDoc, id, (node) => {
       node.text = text;
     });
     setDocContent(newDoc);
   };
-  
+
   const onAddItem = (parentId: string | null) => {
-    const newNode: ListItemNode = { id: generateId(), text: '', children: [] };
-    const newDoc = JSON.parse(JSON.stringify(docContent));
+    const newNode: ListItemNode = { id: generateId(), text: '', isCollapsed: false, children: [] };
+    const newDoc = cloneDocContent();
 
     if (parentId === null) {
       newDoc.push(newNode);
@@ -242,16 +300,18 @@ export default function App() {
         if (node.children.length === 0) {
           siblings.splice(index + 1, 0, newNode);
         } else {
+          node.isCollapsed = false;
           node.children.unshift(newNode);
         }
       });
     }
     setDocContent(newDoc);
     setItemToFocusId(newNode.id);
+    persistLocalViewState(newDoc);
   };
 
   const onDeleteItem = (id: string) => {
-    const newDoc = JSON.parse(JSON.stringify(docContent));
+    const newDoc = cloneDocContent();
     findAndModifyNode(newDoc, id, (node, parent, siblings, index) => {
         siblings.splice(index, 1);
         node.children.reverse().forEach(child => {
@@ -259,23 +319,26 @@ export default function App() {
         });
     });
     setDocContent(newDoc);
+    persistLocalViewState(newDoc);
   };
-  
+
   const onIndent = (id: string) => {
-    const newDoc = JSON.parse(JSON.stringify(docContent));
+    const newDoc = cloneDocContent();
     findAndModifyNode(newDoc, id, (node, parent, siblings, index) => {
       if (index > 0) {
         const newParent = siblings[index - 1];
         const itemToMove = siblings.splice(index, 1)[0];
+        newParent.isCollapsed = false;
         newParent.children.push(itemToMove);
       }
     });
     setDocContent(newDoc);
     setItemToFocusId(id);
+    persistLocalViewState(newDoc);
   };
-  
+
   const onOutdent = (id: string) => {
-    const newDoc = JSON.parse(JSON.stringify(docContent));
+    const newDoc = cloneDocContent();
     findAndModifyNode(newDoc, id, (node, parent, siblings, index) => {
       if (parent) {
         findAndModifyNode(newDoc, parent.id, (greatGrandParent, grandParent, parentSiblings, parentIndex) => {
@@ -289,6 +352,16 @@ export default function App() {
     });
     setDocContent(newDoc);
     setItemToFocusId(id);
+    persistLocalViewState(newDoc);
+  };
+
+  const onToggleCollapse = (id: string) => {
+    const newDoc = cloneDocContent();
+    findAndModifyNode(newDoc, id, (node) => {
+      node.isCollapsed = !node.isCollapsed;
+    });
+    setDocContent(newDoc);
+    persistLocalViewState(newDoc);
   };
 
   const onFocusHandled = () => {
@@ -408,6 +481,7 @@ export default function App() {
               onIndent={onIndent}
               onOutdent={onOutdent}
               onNavigateFocus={onNavigateFocus}
+              onToggleCollapse={onToggleCollapse}
               itemToFocusId={itemToFocusId}
               onFocusHandled={onFocusHandled}
             />

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -12,18 +12,20 @@ interface EditorProps {
   onIndent: (id: string) => void;
   onOutdent: (id: string) => void;
   onNavigateFocus: (id: string, direction: 'up' | 'down') => void;
+  onToggleCollapse: (id: string) => void;
   itemToFocusId: string | null;
   onFocusHandled: () => void;
 }
 
-const Editor: React.FC<EditorProps> = ({ 
-    nodes, 
-    onUpdateText, 
-    onAddItem, 
+const Editor: React.FC<EditorProps> = ({
+    nodes,
+    onUpdateText,
+    onAddItem,
     onDeleteItem,
     onIndent,
     onOutdent,
     onNavigateFocus,
+    onToggleCollapse,
     itemToFocusId,
     onFocusHandled
 }) => {
@@ -41,6 +43,7 @@ const Editor: React.FC<EditorProps> = ({
             onIndent={onIndent}
             onOutdent={onOutdent}
             onNavigateFocus={onNavigateFocus}
+            onToggleCollapse={onToggleCollapse}
             isFirst={index === 0}
             isLast={index === nodes.length - 1}
             parentIsRoot={true}

--- a/components/EditorItem.tsx
+++ b/components/EditorItem.tsx
@@ -1,7 +1,7 @@
 
 import React, { useRef, useEffect } from 'react';
 import { ListItemNode } from '../types';
-import { TrashIcon, ArrowRightIcon, ArrowLeftIcon } from './icons';
+import { TrashIcon, ArrowRightIcon, ArrowLeftIcon, ChevronDownIcon, ChevronRightIcon } from './icons';
 
 interface EditorItemProps {
   node: ListItemNode;
@@ -12,6 +12,7 @@ interface EditorItemProps {
   onIndent: (id: string) => void;
   onOutdent: (id: string) => void;
   onNavigateFocus: (id: string, direction: 'up' | 'down') => void;
+  onToggleCollapse: (id: string) => void;
   isFirst: boolean;
   isLast: boolean;
   parentIsRoot: boolean;
@@ -28,6 +29,7 @@ const EditorItem: React.FC<EditorItemProps> = ({
   onIndent,
   onOutdent,
   onNavigateFocus,
+  onToggleCollapse,
   isFirst,
   isLast,
   parentIsRoot,
@@ -35,6 +37,7 @@ const EditorItem: React.FC<EditorItemProps> = ({
   onFocusHandled,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const hasChildren = node.children.length > 0;
 
   useEffect(() => {
     if (itemToFocusId === node.id && inputRef.current) {
@@ -67,6 +70,22 @@ const EditorItem: React.FC<EditorItemProps> = ({
   return (
     <div className="flex flex-col">
       <div className="flex items-center group space-x-2 py-1">
+        {hasChildren ? (
+          <button
+            onClick={() => onToggleCollapse(node.id)}
+            title={node.isCollapsed ? 'Expand children' : 'Collapse children'}
+            className="flex-shrink-0 p-1 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-500"
+            aria-label={node.isCollapsed ? 'Expand children' : 'Collapse children'}
+          >
+            {node.isCollapsed ? (
+              <ChevronRightIcon className="w-4 h-4" />
+            ) : (
+              <ChevronDownIcon className="w-4 h-4" />
+            )}
+          </button>
+        ) : (
+          <span className="w-6" />
+        )}
         <input
           ref={inputRef}
           type="text"
@@ -88,27 +107,30 @@ const EditorItem: React.FC<EditorItemProps> = ({
             </button>
         </div>
       </div>
-      <div style={{ paddingLeft: `1.5rem` }} className="relative">
-        {node.children.length > 0 && <div className="absolute left-0 top-0 bottom-0 w-px bg-slate-200 dark:bg-slate-700 ml-3"></div>}
-        {node.children.map((childNode, index) => (
-          <EditorItem
-            key={childNode.id}
-            node={childNode}
-            level={level + 1}
-            onUpdateText={onUpdateText}
-            onAddItem={onAddItem}
-            onDeleteItem={onDeleteItem}
-            onIndent={onIndent}
-            onOutdent={onOutdent}
-            onNavigateFocus={onNavigateFocus}
-            isFirst={index === 0}
-            isLast={index === node.children.length - 1}
-            parentIsRoot={false}
-            itemToFocusId={itemToFocusId}
-            onFocusHandled={onFocusHandled}
-          />
-        ))}
-      </div>
+      {hasChildren && !node.isCollapsed && (
+        <div style={{ paddingLeft: `1.5rem` }} className="relative">
+          <div className="absolute left-0 top-0 bottom-0 w-px bg-slate-200 dark:bg-slate-700 ml-3"></div>
+          {node.children.map((childNode, index) => (
+            <EditorItem
+              key={childNode.id}
+              node={childNode}
+              level={level + 1}
+              onUpdateText={onUpdateText}
+              onAddItem={onAddItem}
+              onDeleteItem={onDeleteItem}
+              onIndent={onIndent}
+              onOutdent={onOutdent}
+              onNavigateFocus={onNavigateFocus}
+              onToggleCollapse={onToggleCollapse}
+              isFirst={index === 0}
+              isLast={index === node.children.length - 1}
+              parentIsRoot={false}
+              itemToFocusId={itemToFocusId}
+              onFocusHandled={onFocusHandled}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -26,6 +26,18 @@ export const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+export const ChevronDownIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+  </svg>
+);
+
+export const ChevronRightIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+  </svg>
+);
+
 export const SaveIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
     <path strokeLinecap="round" strokeLinejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338A2.25 2.25 0 0 0 17.088 3.75H15M12 3.75v12.75m0 0-3-3m3 3 3-3M3.75 6.75h16.5" />

--- a/services/localStorage.ts
+++ b/services/localStorage.ts
@@ -1,8 +1,9 @@
 
-import { AppFile } from '../types';
+import { AppFile, DocumentViewState } from '../types';
 
 const FILE_INDEX_KEY = 'marktree_local_files_index';
 const FILE_CONTENT_PREFIX = 'marktree_local_file_';
+const FILE_VIEWSTATE_PREFIX = 'marktree_local_viewstate_';
 
 const generateId = () => `local_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
@@ -57,5 +58,25 @@ export const deleteDocument = async (docId: string): Promise<void> => {
   index = index.filter(file => file.id !== docId);
   setFileIndex(index);
   localStorage.removeItem(`${FILE_CONTENT_PREFIX}${docId}`);
+  localStorage.removeItem(`${FILE_VIEWSTATE_PREFIX}${docId}`);
+  return Promise.resolve();
+};
+
+export const getDocumentViewState = async (docId: string): Promise<DocumentViewState | null> => {
+  const stored = localStorage.getItem(`${FILE_VIEWSTATE_PREFIX}${docId}`);
+  if (!stored) {
+    return Promise.resolve(null);
+  }
+
+  try {
+    return Promise.resolve(JSON.parse(stored));
+  } catch (error) {
+    console.error('Failed to parse document view state', error);
+    return Promise.resolve(null);
+  }
+};
+
+export const updateDocumentViewState = async (docId: string, state: DocumentViewState): Promise<void> => {
+  localStorage.setItem(`${FILE_VIEWSTATE_PREFIX}${docId}`, JSON.stringify(state));
   return Promise.resolve();
 };

--- a/services/markdownParser.ts
+++ b/services/markdownParser.ts
@@ -20,6 +20,7 @@ export const parseMarkdown = (markdown: string): ListItemNode[] => {
     const newNode: ListItemNode = {
       id: generateId(),
       text,
+      isCollapsed: false,
       children: [],
     };
 

--- a/types.ts
+++ b/types.ts
@@ -1,12 +1,17 @@
 export interface ListItemNode {
   id: string;
   text: string;
+  isCollapsed: boolean;
   children: ListItemNode[];
 }
 
 export interface AppFile {
   id: string;
   name: string;
+}
+
+export interface DocumentViewState {
+  collapsedPaths: number[][];
 }
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- add collapse and expand controls to editor items and hide collapsed children from navigation
- persist each document's collapsed paths in local storage and restore them on load
- extend shared types and icons needed to support the collapsible UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91b8b590c8324aa6aa6225d343b7e