### PR TITLE
Handle paragraph leaves in markdown import/export

### DIFF
--- a/services/markdownParser.ts
+++ b/services/markdownParser.ts
@@ -81,13 +81,17 @@ const serializeNode = (node: ListItemNode, level: number): string => {
     return node.text;
   }
 
-  const prefix = '#'.repeat(level);
-  const childrenText = node.children
+  const headingLine = `${'#'.repeat(level)} ${node.text}`;
+  const childrenBlocks = node.children
     .map(child => serializeNode(child, level + 1))
-    .filter(text => text !== '')
-    .join('\n\n');
+    .filter(text => text !== '');
 
-  return `${prefix} ${node.text}${childrenText ? '\n\n' + childrenText : ''}`;
+  if (childrenBlocks.length === 0) {
+    return headingLine;
+  }
+
+  const childrenText = childrenBlocks.join('\n\n');
+  return `${headingLine}\n${childrenText}`;
 };
 
 export const serializeToMarkdown = (nodes: ListItemNode[]): string => {

--- a/services/markdownParser.ts
+++ b/services/markdownParser.ts
@@ -4,19 +4,19 @@ import { ListItemNode } from '../types';
 const generateId = () => `id_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
 export const parseMarkdown = (markdown: string): ListItemNode[] => {
-  const lines = markdown.split('\n').filter(line => line.trim() !== '');
-  if (lines.length === 0) return [];
-
+  const lines = markdown.split(/\r?\n/);
   const rootNodes: ListItemNode[] = [];
-  const parentStack: (ListItemNode | null)[] = [null]; // stack[level] gives parent
+  const parentStack: (ListItemNode | null)[] = [null];
+  let paragraphBuffer: string[] = [];
 
-  lines.forEach(line => {
-    const levelMatch = line.match(/^(#+)\s/);
-    if (!levelMatch) return;
+  const flushParagraph = () => {
+    if (paragraphBuffer.length === 0) return;
 
-    const level = levelMatch[1].length;
-    const text = line.substring(levelMatch[0].length);
+    const text = paragraphBuffer.join('\n').trim();
+    paragraphBuffer = [];
+    if (text === '') return;
 
+    const parent = parentStack[parentStack.length - 1] ?? null;
     const newNode: ListItemNode = {
       id: generateId(),
       text,
@@ -24,32 +24,75 @@ export const parseMarkdown = (markdown: string): ListItemNode[] => {
       children: [],
     };
 
-    while (parentStack.length > level) {
-      parentStack.pop();
-    }
-
-    const parent = parentStack[parentStack.length - 1];
-
     if (parent) {
       parent.children.push(newNode);
     } else {
       rootNodes.push(newNode);
     }
-    
-    parentStack.push(newNode);
+  };
+
+  lines.forEach(line => {
+    const trimmedLine = line.trim();
+
+    if (trimmedLine === '') {
+      flushParagraph();
+      return;
+    }
+
+    const levelMatch = line.match(/^(#+)\s+(.*)$/);
+    if (levelMatch) {
+      flushParagraph();
+
+      const level = levelMatch[1].length;
+      const text = levelMatch[2].trim();
+
+      const newNode: ListItemNode = {
+        id: generateId(),
+        text,
+        isCollapsed: false,
+        children: [],
+      };
+
+      while (parentStack.length > level) {
+        parentStack.pop();
+      }
+
+      const parent = parentStack[parentStack.length - 1] ?? null;
+
+      if (parent) {
+        parent.children.push(newNode);
+      } else {
+        rootNodes.push(newNode);
+      }
+
+      parentStack.push(newNode);
+    } else {
+      paragraphBuffer.push(trimmedLine);
+    }
   });
+
+  flushParagraph();
 
   return rootNodes;
 };
 
-
 const serializeNode = (node: ListItemNode, level: number): string => {
+  if (node.children.length === 0) {
+    return node.text;
+  }
+
   const prefix = '#'.repeat(level);
-  const currentNodeText = `${prefix} ${node.text}`;
-  const childrenText = node.children.map(child => serializeNode(child, level + 1)).join('\n');
-  return `${currentNodeText}${childrenText ? '\n' + childrenText : ''}`;
+  const childrenText = node.children
+    .map(child => serializeNode(child, level + 1))
+    .filter(text => text !== '')
+    .join('\n\n');
+
+  return `${prefix} ${node.text}${childrenText ? '\n\n' + childrenText : ''}`;
 };
 
 export const serializeToMarkdown = (nodes: ListItemNode[]): string => {
-  return nodes.map(node => serializeNode(node, 1)).join('\n');
+  return nodes
+    .map(node => serializeNode(node, 1))
+    .filter(text => text !== '')
+    .join('\n\n');
 };


### PR DESCRIPTION
## Summary
- export leaf nodes as paragraphs instead of headings so childless items remain text
- update the markdown parser to attach paragraph blocks to the proper parent when importing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9271756288324b7e56f4d8aecb2fe