### PR TITLE
Add autosave debounce for authenticated sessions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -334,6 +334,18 @@ export default function App() {
     return () => clearTimeout(timeoutId);
   }, [currentFile, docContent, saveFile, user]);
 
+  useEffect(() => {
+    if (!currentFile || !user?.uid) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      void saveFile();
+    }, 10000);
+
+    return () => clearTimeout(timeoutId);
+  }, [currentFile, docContent, saveFile, user]);
+
   const deleteFile = async (file: AppFile) => {
     if (!window.confirm(`Are you sure you want to delete "${file.name}"? This action cannot be undone.`)) {
       return;


### PR DESCRIPTION
## Summary
- add a dedicated autosave effect for authenticated users with a 10-second debounce to persist changes automatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d939565bbc832495f4b0a6bfb2fbcb