### PR TITLE
Switch markdown parser tests to Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react-dom": "^19.1.1",
@@ -17,6 +19,7 @@
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.5"
   }
 }

--- a/services/markdownParser.test.ts
+++ b/services/markdownParser.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseMarkdown, serializeToMarkdown } from './markdownParser';
+import type { ListItemNode } from '../types';
+
+describe('parseMarkdown', () => {
+  it('creates a hierarchical node tree from markdown headings and paragraphs', () => {
+    const markdown = [
+      '# Heading 1',
+      'Paragraph under heading 1',
+      '',
+      '## Heading 1.1',
+      'Nested paragraph',
+      '',
+      '# Heading 2',
+      'Paragraph under heading 2',
+    ].join('\n');
+
+    const result = parseMarkdown(markdown);
+
+    expect(result).toHaveLength(2);
+
+    const [firstHeading, secondHeading] = result;
+
+    expect(firstHeading.text).toBe('Heading 1');
+    expect(firstHeading.isCollapsed).toBe(false);
+    expect(firstHeading.children).toHaveLength(2);
+    expect(firstHeading.children[0]?.text).toBe('Paragraph under heading 1');
+
+    const nestedHeading = firstHeading.children[1];
+    expect(nestedHeading?.text).toBe('Heading 1.1');
+    expect(nestedHeading?.children).toHaveLength(1);
+    expect(nestedHeading?.children[0]?.text).toBe('Nested paragraph');
+
+    expect(secondHeading.text).toBe('Heading 2');
+    expect(secondHeading.children).toHaveLength(1);
+    expect(secondHeading.children[0]?.text).toBe('Paragraph under heading 2');
+  });
+
+  it('treats standalone paragraphs as top-level nodes', () => {
+    const markdown = [
+      'First paragraph',
+      '',
+      'Second paragraph',
+    ].join('\n');
+
+    const result = parseMarkdown(markdown);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(node => node.text)).toEqual([
+      'First paragraph',
+      'Second paragraph',
+    ]);
+  });
+});
+
+describe('serializeToMarkdown', () => {
+  it('renders nodes with nested headings and paragraphs to markdown text', () => {
+    const nodes: ListItemNode[] = [
+      {
+        id: '1',
+        text: 'Heading 1',
+        isCollapsed: false,
+        children: [
+          {
+            id: '1-1',
+            text: 'Paragraph under heading 1',
+            isCollapsed: false,
+            children: [],
+          },
+          {
+            id: '1-2',
+            text: 'Heading 1.1',
+            isCollapsed: false,
+            children: [
+              {
+                id: '1-2-1',
+                text: 'Nested paragraph',
+                isCollapsed: false,
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: '2',
+        text: 'Standalone paragraph',
+        isCollapsed: false,
+        children: [],
+      },
+    ];
+
+    expect(serializeToMarkdown(nodes)).toBe(
+      [
+        '# Heading 1',
+        'Paragraph under heading 1',
+        '',
+        '## Heading 1.1',
+        'Nested paragraph',
+        '',
+        'Standalone paragraph',
+      ].join('\n'),
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import path from 'path';
-import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
@@ -29,6 +30,10 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
-      }
+      },
+      test: {
+        environment: 'node',
+        include: ['services/**/*.test.ts'],
+      },
     };
 });


### PR DESCRIPTION
## Summary
- replace the markdown parser unit tests to run under Vitest instead of the Node test runner
- update package tooling to call Vitest directly and configure the Vite test environment
- remove the bespoke TypeScript test compilation config that is no longer needed

## Testing
- npm test *(fails in the sandbox: Vitest is not installed because npm cannot download the package from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9349b2c98832485bcb9456e8fb4a8